### PR TITLE
Wallfollower2

### DIFF
--- a/self_drive/self_drive/self_drive.py
+++ b/self_drive/self_drive/self_drive.py
@@ -32,6 +32,7 @@ class SelfDrive(Node):
             twist.angular.z = 0.
             self.get_logger().info(f"scan: {scan.ranges[0]}, forward")
         else:
+            turning = False
             if (0 < scan.ranges[45] < 0.18 or 0 < scan.ranges[55] < 0.18 or 0 < scan.ranges[35] < 0.18 or 0 < scan.ranges[25] < 0.18):
                 twist.linear.x = 0.2
                 twist.angular.z = -0.22
@@ -41,6 +42,8 @@ class SelfDrive(Node):
             else:
                 twist.linear.x = 0.2
                 twist.angular.z = 0.
+            if  scan.ranges[60] > 0.25 or scan.ranges[50] > 0.25 or scan.ranges[40] > 0.25:
+                turning = True
         self.pub_velo.publish(twist)
 
 def main(args=None):

--- a/self_drive/self_drive/self_drive.py
+++ b/self_drive/self_drive/self_drive.py
@@ -44,6 +44,13 @@ class SelfDrive(Node):
                 twist.angular.z = 0.
             if  scan.ranges[60] > 0.25 or scan.ranges[50] > 0.25 or scan.ranges[40] > 0.25:
                 turning = True
+            if turning:
+                if (0 < scan.ranges[145] < 0.25 or 0 < scan.ranges[135] < 0.25 or 0 < scan.ranges[125] < 0.25) or (0 < scan.ranges[115] < 0.25 or 0 < scan.ranges[105] < 0.25 or 0 < scan.ranges[95] < 0.25) or (0 < scan.ranges[85] < 0.25 or 0 < scan.ranges[75] < 0.25 or 0 < scan.ranges[65] < 0.25) or (0 < scan.ranges[55] < 0.25 or 0 < scan.ranges[45] < 0.25):
+                    twist.linear.x = 0.2
+                    twist.angular.z = 1.5
+                    self.get_logger().info(f"scan: {scan.ranges[0]}, turning")
+                else:
+                    turning = False
         self.pub_velo.publish(twist)
 
 def main(args=None):


### PR DESCRIPTION
기존에 wallfollowing 조건에 벽 끝 모서리를 만나면 turning할 수 있는 조건을 추가하였습니다.
우선 변수 turning 조건을 만들었습니다.
이 변수 turning은 벽 끝 모서리를 지나면 True가 되도록 프로그래밍하였습니다.
전방 60도, 50도, 40도에서 장애물이 감지가 안될 때(25cm 이상) 변수 turning이 True가 됩니다.
이 turning이 True가 되면 왼쪽 뒤에 벽이 있을 때(단순히 주변에 장애물이 없는 것이 아니라 뒤에 장애물이 있음을 감지함으로써 벽 모서리임을 인식), 벽을 완전히 회전하는 동안 turning할 수 있는 조건을 프로그래밍하였습니다.
전방 기준 145도, 135도, 125도, 115도, 105도, 95도, 85도, 75도, 65도, 55도, 45도에서 25cm안에 장애물이 감지되는 동안 전방 0.2속도와 1.5 회전속도로 turning합니다.
turning이 완전히 끝나면 변수 turning을 False로 바꾸어 turning이 끝나게하였습니다.
turning하는 동안 turning이라는 문구를 받을 수 있게 하였습니다.
터미널에서 turning 동작을 확인할 수 있습니다.
이상 없으면 merge 부탁드립니다.